### PR TITLE
Fixed Line Drawing Error

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,7 @@
 
 
         function startDrawing(e) {
+            ctx.moveTo(e.clientX, e.clientY);
             drawing = true;
             draw(e);
         }


### PR DESCRIPTION
Fixed error in which line would fill in from last location to new mouse location. Still needs tweaking because at least on laptop, curves the beginning of the line.