### PR TITLE
Spider webbing issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,10 @@ def draw(data):
     drawings.append(data)
     emit('drawing', data, broadcast=True)
 
+@socketio.on('stop_drawing')
+def stop_drawing():
+    emit('stop_drawing', broadcast=True)
+
 @socketio.on('clear')
 def clear():
     drawings.clear()  # Clear the drawings list

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,7 @@
         function stopDrawing() {
             drawing = false;
             ctx.beginPath();
+            socket.emit("stop_drawing");
         }
 
         function clearCanvas(e) {
@@ -47,7 +48,6 @@
 
         function draw(e) {
             if (!drawing) return;
-
             ctx.lineWidth = 2;
             ctx.lineCap = 'round';
             ctx.strokeStyle = 'black';
@@ -77,21 +77,27 @@
             ctx.moveTo(data.x, data.y);
         });
 
-        // Retrieve existing drawings from the server
-        fetch('/get_drawings')
-            .then(response => response.json())
-            .then(data => {
-                data.drawings.forEach(d => {
-                    ctx.lineWidth = 2;
-                    ctx.lineCap = 'round';
-                    ctx.strokeStyle = 'black';
+        socket.on('stop_drawing', (data) => {
+            ctx.beginPath();
+        });
 
-                    ctx.lineTo(d.x, d.y);
-                    ctx.stroke();
-                    ctx.beginPath();
-                    ctx.moveTo(d.x, d.y);
-                });
-            });
+        // Retrieve existing drawings from the server
+        // fetch('/get_drawings')
+        //     .then(response => response.json())
+        //     .then(data => {
+        //         data.drawings.forEach(d => {
+
+        //                 ctx.lineWidth = 2;
+        //                 ctx.lineCap = 'round';
+        //                 ctx.strokeStyle = 'black';
+
+        //                 ctx.lineTo(d.x, d.y);
+        //                 ctx.stroke();
+        //                 ctx.beginPath();
+        //                 ctx.moveTo(d.x, d.y);
+        //                 count = count + 1;
+        //         });
+        //     });
     </script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,6 +66,7 @@
 
         // Listen for drawing data from the server
         socket.on('drawing', (data) => {
+            if (drawing) return;
             ctx.lineWidth = 2;
             ctx.lineCap = 'round';
             ctx.strokeStyle = 'black';


### PR DESCRIPTION
Fixes issues with the "spider webbing" effects and connecting lines between strokes when connected clients aren't the ones drawing. 

Resolution Summary:
1. Added a check for whether the client is the one drawing in socket.on('drawing'). If the client is the one drawing, then it ignores the request. This fixes the spider webbing issue where it tries to draw multiple lines along the cursor.
2. Added socket functions to emit a "stop drawing" check. This fixes the issues where strokes were connected on the non-drawing clients. This check resets the path position so it doesn't get stuck on the last stroke and try to connect strokes.
3. Commented out the fetch /get drawings function. I believe this function is supposed to load all the drawings on a refresh or initial connect. It wasn't working for me so I commented it out. We should create a new branch to test this feature and add it back in.